### PR TITLE
:fire: Auditing 클래스 추가

### DIFF
--- a/domain/src/main/java/com/depromeet/ahmatda/config/JpaAuditingConfig.java
+++ b/domain/src/main/java/com/depromeet/ahmatda/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.depromeet.ahmatda.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+}

--- a/domain/src/main/java/com/depromeet/ahmatda/domain/BaseTimeEntity.java
+++ b/domain/src/main/java/com/depromeet/ahmatda/domain/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.depromeet.ahmatda.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
Auditing Class  추가입니다.

JpaAuditingConfig 는 저희 모듈 구분 상 inner-system이 맞지 않을까 생각하기도 했는데...

JPA 디펜던시를 inner-system 모듈에 추가하는 것보다는 domain 내부 config 폴더에 관리하는 것이 맞을 것 같다고 판단했습니다.

![image](https://user-images.githubusercontent.com/87016418/203704922-5b1d81b9-6545-4622-90cd-a90ae3fe8920.png)
정상 적용 확인 완료.

참고 : https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#jpa.auditing