### PR TITLE
:wrench: 로그 파일의 최대 용량을 3기가로 설정합니다

### DIFF
--- a/application/src/main/resources/logback-production.xml
+++ b/application/src/main/resources/logback-production.xml
@@ -7,6 +7,7 @@
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <fileNamePattern>${LOG_PATH}/rolling/production.%d{yyyy-MM-dd}.log</fileNamePattern>
       <maxHistory>30</maxHistory>
+      <maxFileSize>3GB</maxFileSize>
     </rollingPolicy>
 
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">


### PR DESCRIPTION
로그파일의 용량이 5GB를 차지하여 EC2 인스턴스 용량이 최대가 되었으므로 로그 파일의 최대 용량을 조절합니다.